### PR TITLE
docs(smoke): usage for impl1 flags and once.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,5 +160,9 @@ scripts/smoke/once.sh --mark-done
 ├─ docs/systemd/ae-telemetry-archive.timer
 ├─ .github/workflows/exec-healthcheck.yml
 ├─ .github/workflows/smoke.yml
+│  └─ backlog/sync.sh
+│  └─ admin/seed-labels.sh
+│  └─ smoke/impl1.sh
+│  └─ smoke/once.sh
 └─ .github/workflows/lint.yml
 ```


### PR DESCRIPTION
Add concise docs for smoke helpers.\n\n- impl1.sh: document --mark-done and --issue\n- once.sh: CI/one-shot usage example\n- Update file tree listing\n\nRefs: #21