### PR TITLE
feat(watcher): WATCH_DRY_RUN to simulate /start without posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ export ZELLIJ_SESSION=codex-impl-1         # セッション名
 export CODEX_AUTOPILOT=1
 ```
 
+環境変数（任意のチューニング）
+- `DISPATCH_COOLDOWN_SECONDS` (default: `600`) — ウォッチャーが直近で `/start` コメント済みの場合、同一 Issue への再ディスパッチをスキップするクールダウン秒数。
+- `WATCH_DRY_RUN` (default: `0`) — `1` にするとディスパッチをシミュレーション（`/start` コメントやラベル変更は行わず、ステータスに `dry-run` を記録）。CI 等で安全に動作確認したい場合に便利。
+
 3) 実行
 ```bash
 export GH_REPO="itdojp/ae-orchestrator"      # 管理対象リポジトリ


### PR DESCRIPTION
Adds WATCH_DRY_RUN=1 mode to the watcher.\n\n- Skips posting '/start' and label mutations\n- Records last_action result as 'dry-run' in status\n- Emits dispatch event with dry-run=1\n\nUse for safe CI/tests where commenting is undesired.\n\nRefs: #21